### PR TITLE
Rename `ocp` image to `fedora-osh-hub`

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -17,9 +17,7 @@ jobs:
           registry_token: ${{ secrets.REGISTRY_TOKEN }}
           dockerfile: "containers/hub.Containerfile"
           docker_context: "containers"
-          # TODO: Rename this image to `fedora-osh-hub` (or osh-hub).
-          # Keep the name consistent with container name in OpenShift.
-          image_name: "ocp"
+          image_name: "fedora-osh-hub"
           tag: "staging"
   build-and-push-resalloc-server:
     runs-on: ubuntu-20.04

--- a/containers/hub.Containerfile
+++ b/containers/hub.Containerfile
@@ -1,4 +1,4 @@
-# Builds should be available on https://quay.io/organization/openscanhub-fedora-infra/ocp
+# Builds should be available on https://quay.io/organization/openscanhub-fedora-infra/fedora-osh-hub
 # TODO: Check if we can use ubi.
 # resalloc dependencies require a subscription.
 # FROM registry.access.redhat.com/ubi9/httpd-24


### PR DESCRIPTION
to keep the name consistent with the container names.