### PR TITLE
Add ssh configurations for the resalloc-server

### DIFF
--- a/containers/configs/ssh_config
+++ b/containers/configs/ssh_config
@@ -1,0 +1,13 @@
+Host *
+   IdentityFile ~/.ssh/id_rsa
+   StrictHostKeyChecking  no
+   UserKnownHostsFile /dev/null
+   ServerAliveInterval 20
+   ServerAliveCountMax 5
+   ConnectTimeout 60
+   # Be careful with patterns so the socket filename is not too long:
+   # unix_listener: path "/var/lib/resallocserver/.ssh/.ssh_socket_vmhost-x86-copr04.rdu-cc.fedoraproject.org_22_copr.8bslqLJka7WO6iIQ" too long for Unix domain socket: Connection reset by peer
+   # See: https://stackoverflow.com/questions/34829600/why-is-the-maximal-path-length-allowed-for-unix-sockets-on-linux-108
+   ControlPath=~/.ssh/skt_%h_%p_%r
+   ControlMaster=auto
+   ControlPersist=60

--- a/containers/resalloc-server.Containerfile
+++ b/containers/resalloc-server.Containerfile
@@ -45,8 +45,13 @@ COPY vm-provisioning /etc/resallocserver/vm-provisioning
 # RUN git clone --branch main https://github.com/siteshwar/openscanhub-deployment-configs.git /etc/resallocserver/openscanhub-deployment-configs
 # COPY openscanhub-deployment-configs /etc/resallocserver/openscanhub-deployment-configs
 
-USER 1001
 ENV HOME=/var/lib/resallocserver
 ENV CONFIG_DIR=/etc/resallocserver
+
+# `ControlPath` should be writable by `root` group.
+RUN chmod -R g+rwx $HOME/.ssh
+COPY configs/ssh_config $HOME/.ssh/config
+
+USER 1001
 CMD /usr/bin/resalloc-server
 # CMD sleep inf


### PR DESCRIPTION
Use `ControlMaster` option to avoid ssh connection timeout errors.