### PR TITLE
Disable xz sandbox

### DIFF
--- a/containers/vm-provisioning/ansible/roles/osh-worker-role/files/fedora-rawhide-gcc-latest-x86_64.cfg
+++ b/containers/vm-provisioning/ansible/roles/osh-worker-role/files/fedora-rawhide-gcc-latest-x86_64.cfg
@@ -10,6 +10,8 @@ config_opts['isolation'] = 'unchanged'
 
 config_opts['dnf.conf'] += """
 
+config_opts['environment']['XZ_DISABLE_SANDBOX'] = '1'
+
 [copr_base]
 name="Copr repository"
 baseurl=https://download.copr.fedorainfracloud.org/results/dmalcolm/gcc-latest/fedora-rawhide-x86_64/


### PR DESCRIPTION
```
+ /usr/lib/rpm/rpmuncompress -x /builddir/build/SOURCES/libvirt-11.6.0.tar.xz
/usr/bin/xz: Failed to enable the sandbox
/usr/bin/tar: This does not look like a tar archive
/usr/bin/tar: Exiting with failure status due to previous errors
```

Related:
https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/message/X7OBENN7JWOV2I77YW72OH3TAWK7S7OF/ https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/message/65BDSY56R5ZJRTUC4B6CIVCVLY4LG4ME/